### PR TITLE
Fix documentation (links and samples)

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ standalone [Ceph] cluster that trivializes integrating with
 default.
 
 If you are new to [Ceph], please see the following:
-* https://docs.ceph.com/docs/octopus/start/hardware-recommendations/
-* https://docs.ceph.com/docs/octopus/start/os-recommendations/
-* https://docs.ceph.com/docs/octopus/cephadm/
+* https://docs.ceph.com/en/octopus/start/hardware-recommendations/
+* https://docs.ceph.com/en/octopus/start/os-recommendations/
+* https://docs.ceph.com/en/octopus/cephadm/
 
 
 Goals
@@ -50,7 +50,7 @@ Configure
 -------------------
 1. Create your inventory
 
-    Make a copy of `inventory.sample.yml`:
+    Make a copy of `sample.inventory.yml`:
 
     ```sh
     $ cp {sample.,}inventory.yml
@@ -61,10 +61,10 @@ Configure
 
 2. Define your configuration
 
-    Make a copy of `group_vars/all.sample.yml`:
+    Make a copy of `group_vars/sample.all.yml`:
 
     ```sh
-    $ cp group_vars/all{.sample,}.yml
+    $ cp group_vars/{sample.,}all.yml
     ```
 
     Read over the created `group_vars/all.yml` and adjust the variables
@@ -102,9 +102,9 @@ for additional logic to be added to this playbook.
 [cephadm-ansible]: https://github.com/jcmdln/cephadm-ansible
 
 [Ceph]: https://ceph.io/
-[Ceph Orchestrator]: https://docs.ceph.com/docs/octopus/mgr/orchestrator/
-[Ceph Orch]: https://docs.ceph.com/docs/octopus/mgr/orchestrator/
-[cephadm]: https://docs.ceph.com/docs/octopus/cephadm/
+[Ceph Orchestrator]: https://docs.ceph.com/en/octopus/mgr/orchestrator/
+[Ceph Orch]: https://docs.ceph.com/en/octopus/mgr/orchestrator/
+[cephadm]: https://docs.ceph.com/en/octopus/cephadm/
 [ceph-ansible]: https://github.com/ceph/ceph-ansible
 
 [kolla-ansible]: https://github.com/openstack/kolla-ansible

--- a/group_vars/sample.all.yml
+++ b/group_vars/sample.all.yml
@@ -98,7 +98,7 @@ cephadm_network_interface_rgws: "{{ cephadm_network_interface_public }}"
 # OSDs
 #
 
-# https://docs.ceph.com/docs/octopus/cephadm/drivegroups/
+# https://docs.ceph.com/en/octopus/cephadm/drivegroups/
 cephadm_osd_drivegroups:
   - service_type: osd
     service_id: default_drive_group

--- a/sample.inventory.yml
+++ b/sample.inventory.yml
@@ -1,4 +1,4 @@
-# inventory.sample.yml
+# sample.inventory.yml
 
 # These hosts will have ceph-mgr deployed to them.  In general the
 # Ceph recommendation is to co-mingle ceph-mgr and ceph-mon, but you


### PR DESCRIPTION
This fixes broken links to official ceph documentation. /docs moved to /en
except for https://docs.ceph.com/en/latest/releases/octopus/.

The sample inventory and group_vars were renamed but some spots where they were
referenced were not changed yet. This commit fixes this.